### PR TITLE
Add SUSE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ Initial postgresql checkout
 
     git clone git://git.postgresql.org/git/postgresql.git $HOME/pgsql/master
 
-Install tcl-dev, which is necessary for configure-all.sh
+In Ubuntu, install tcl-dev, which is necessary for configure-all.sh
 
     sudo apt-get install tcl-dev
+
+If you use openSUSE, you must install these packages:
+
+    sudo zypper in -t pattern devel_C_C++
+    sudo zypper in tcl-devel libxml2-devel readline-devel libopenssl-devel
 
 Build and install the development head version
 

--- a/configure-all.sh
+++ b/configure-all.sh
@@ -16,6 +16,12 @@ fi
 ARGS="$ARGS --with-tcl --with-libxml --with-openssl"
 DEBUG_ARGS="--enable-depend --enable-cassert --enable-debug"
 CFLAGS="-O0 -g -fno-omit-frame-pointer"
+
+# openSUSE and SUSE have tclConfig.sh in /usr/lib64 for x86_64 machines
+if [ -f "/etc/SuSE-release" ] && [ "$(uname -m)" == 'x86_64' ]; then
+	ARGS="$ARGS --with-tclconfig=/usr/lib64"
+fi
+
 if (which ccache && which clang ) > /dev/null
 then
     ARGS="$ARGS CC='ccache clang -Qunused-arguments -fcolor-diagnostics'"


### PR DESCRIPTION
SUSE and openSUSE have not `tclConfig.sh` in the path, so it must be specified
manually in the `configure` parameters.

Beside this, this commit add a short note in the README file.

Signed-off-by: Leonardo Cecchi leonardo.cecchi@gmail.com
